### PR TITLE
Support custom native object with inlined request

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/native/request/request_test.go
+++ b/native/request/request_test.go
@@ -29,6 +29,25 @@ var _ = Describe("Request", func() {
 			},
 		}))
 	})
+
+	It("should parse prior to 1.1 correctly", func() {
+		req := fixture("testdata/request2.json")
+		Expect(req).To(Equal(&Request{
+			Version:          "1.1",
+			ContextTypeID:    ContextTypeSocial,
+			ContextSubTypeID: ContextSubTypeSocial,
+			PlacementTypeID:  PlacementTypeID(11),
+			PlacementCount:   1,
+			Sequence:         2,
+			Assets: []Asset{
+				{ID: 123, Required: 1, Title: &Title{Length: 140}},
+				{ID: 128, Image: &Image{TypeID: ImageTypeMain, WidthMin: 836, HeightMin: 627, Width: 1000, Height: 800, MIMEs: []string{"image/jpg"}}},
+				{ID: 126, Required: 1, Data: &Data{TypeID: DataTypeSponsored, Length: 25}},
+				{ID: 127, Required: 1, Data: &Data{TypeID: DataTypeDesc, Length: 140}},
+				{ID: 4, Video: &Video{MinDuration: 15, MaxDuration: 30, Protocols: []openrtb.Protocol{openrtb.ProtocolVAST2, openrtb.ProtocolVAST3}, MIMEs: []string{"video/mp4"}}},
+			},
+		}))
+	})
 })
 
 func TestSuite(t *testing.T) {

--- a/native/request/testdata/request2.json
+++ b/native/request/testdata/request2.json
@@ -1,0 +1,64 @@
+{
+  "native": {
+    "ver": "1.1",
+    "context": 2,
+    "contextsubtype": 20,
+    "plcmttype": 11,
+    "plcmtcnt": 1,
+    "seq": 2,
+    "assets": [
+      {
+        "id": 123,
+        "required": 1,
+        "title": {
+          "len": 140
+        }
+      },
+      {
+        "id": 128,
+        "required": 0,
+        "img": {
+          "w": 1000,
+          "h": 800,
+          "mimes": [
+            "image/jpg"
+          ],
+          "wmin": 836,
+          "hmin": 627,
+          "type": 3
+        }
+      },
+      {
+        "id": 126,
+        "required": 1,
+        "data": {
+          "type": 1,
+          "len": 25
+        }
+      },
+      {
+        "id": 127,
+        "required": 1,
+        "data": {
+          "type": 2,
+          "len": 140
+        }
+      },
+      {
+        "id": 4,
+        "video": {
+          "linearity": 1,
+          "minduration": 15,
+          "maxduration": 30,
+          "protocols": [
+            2,
+            3
+          ],
+          "mimes": [
+            "video/mp4"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/native_test.go
+++ b/native_test.go
@@ -8,16 +8,24 @@ import (
 )
 
 var _ = Describe("Native", func() {
-	var subject *Native
-
-	BeforeEach(func() {
-		Expect(fixture("native", &subject)).To(Succeed())
-	})
-
 	It("should parse correctly", func() {
+		var subject *Native
+		Expect(fixture("native", &subject)).To(Succeed())
 		Expect(subject).To(Equal(&Native{
 			Request: json.RawMessage(`"PAYLOAD"`),
 			Version: "2",
+		}))
+	})
+
+	It("should parse asian correctly", func() {
+		var (
+			subject *Native
+			expect  json.RawMessage
+		)
+		Expect(fixture("asian_native", &subject)).To(Succeed())
+		Expect(fixture("asian_native", &expect)).To(Succeed())
+		Expect(subject).To(Equal(&Native{
+			Request: expect,
 		}))
 	})
 })

--- a/testdata/asian_native.json
+++ b/testdata/asian_native.json
@@ -1,0 +1,34 @@
+{
+  "assets": [
+    {
+      "id": 1,
+      "required": 1,
+      "title": {
+        "len": 140
+      }
+    },
+    {
+      "id": 2,
+      "required": 1,
+      "img": {
+        "type": 3,
+        "mimes": [
+          "image/jpg",
+          "image/png",
+          "image/gif"
+        ],
+        "hmin": 160,
+        "wmin": 160
+      }
+    },
+    {
+      "id": 3,
+      "required": 0,
+      "data": {
+        "len": 140,
+        "type": 2
+      }
+    }
+  ],
+  "ver": "1.2"
+}


### PR DESCRIPTION
This PR:
- adds support for custom native objects, when contents of `request` fields is passed instead of `native` root object
- adds support for transparent legacy native requests unmarshaling (prior to 1.1 with `native` field in root)